### PR TITLE
Fix invalid ssh URL for all languages.

### DIFF
--- a/book/ar/ch4-1.html
+++ b/book/ar/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/ch4-1.html
+++ b/book/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/cs/ch4-1.html
+++ b/book/cs/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/de/ch4-2.html
+++ b/book/de/ch4-2.html
@@ -82,7 +82,7 @@ title: Pro Git 4.2 Git on the Server Die Protokolle
 
 <p>Um ein Git Repository über SSH zu clonen, kannst du eine ssh:// URL angeben:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/es-ni/ch4-1.html
+++ b/book/es-ni/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/es/ch4-1.html
+++ b/book/es/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git en un servidor Los Protocolos
 
 <p>Para clonar un repositorio a través de SSH, puedes indicar una URL ssh:// tal como:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>O puedes prescindir del protocolo; Git asume SSH si no indicas nada expresamente: $ git clone user@server:project.git</p>
 

--- a/book/fr/ch4-1.html
+++ b/book/fr/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git sur le serveur Protocoles
 
 <p>Pour cloner une dépôt Git à travers SSH, spécifiez le préfixe <code>ssh://</code> dans l&#8217;URL comme ceci :</p>
 
-<pre><code>$ git clone ssh://utilisateur@serveur:projet.git</code></pre>
+<pre><code>$ git clone ssh://utilisateur@serveur/projet.git</code></pre>
 
 <p>ou ne spécifiez pas de protocole du tout — Git choisit SSH par défaut si vous n&#8217;êtes pas explicite :</p>
 

--- a/book/ja/ch4-1.html
+++ b/book/ja/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git サーバー プロトコル
 
 <p>Git リポジトリを SSH 越しにクローンするには、次のように ssh:// URL を指定します。</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>あるいは、プロトコルを省略することもできます。プロトコルを明示しなくても、Git はそれが SSH であると見なします。</p>
 

--- a/book/mk/ch4-1.html
+++ b/book/mk/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/nl/ch4-1.html
+++ b/book/nl/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git op de Server De Protocollen
 
 <p>Om een Git repository via SSH te clonen, kun je een ssh:// URL opgeven zoals:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Of je geeft geen protocol op – Git gaat uit van SSH als je niet expliciet bent:</p>
 

--- a/book/pl/ch4-1.html
+++ b/book/pl/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git na serwerze Protokoły
 
 <p>Aby sklonować repozytorium Git po SSH, użyj przedrostka <code>ssh://</code> jak poniżej:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Możesz także nie określać protokołu - Git zakłada właśnie SSH, jeśli go nie określisz:</p>
 

--- a/book/pt-br/ch4-1.html
+++ b/book/pt-br/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/ru/ch4-1.html
+++ b/book/ru/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git на сервере Протоколы
 
 <p>Чтобы склонировать Git-репозиторий по SSH, вы можете указать префикс ssh:// в URL, например:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Или вы можете не указывать протокол, Git подразумевает использование SSH, если вы не указали протокол явно:</p>
 

--- a/book/th/ch4-1.html
+++ b/book/th/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 Git on the Server The Protocols
 
 <p>To clone a Git repository over SSH, you can specify ssh:// URL like this:</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>Or you can not specify a protocol — Git assumes SSH if you aren’t explicit:</p>
 

--- a/book/zh/ch4-1.html
+++ b/book/zh/ch4-1.html
@@ -46,7 +46,7 @@ title: Pro Git 4.1 服务器上的 Git 协议
 
 <p>通过 SSH 克隆一个 Git 仓库，你可以像下面这样给出 ssh:// 的 URL：</p>
 
-<pre><code>$ git clone ssh://user@server:project.git</code></pre>
+<pre><code>$ git clone ssh://user@server/project.git</code></pre>
 
 <p>或者不指明某个协议 — 这时 Git 会默认使用 SSH ：</p>
 

--- a/translations/es/GitPro-omegat-Benzirpi.tmx
+++ b/translations/es/GitPro-omegat-Benzirpi.tmx
@@ -9501,10 +9501,10 @@ Figura 3-39.</seg>
     </tu>
     <tu>
       <tuv lang="EN">
-        <seg>$ git clone ssh://user@server:project.git</seg>
+        <seg>$ git clone ssh://user@server/project.git</seg>
       </tuv>
       <tuv lang="ES">
-        <seg>$ git clone ssh://user@server:project.git</seg>
+        <seg>$ git clone ssh://user@server/project.git</seg>
       </tuv>
     </tu>
     <tu>


### PR DESCRIPTION
The current version of this book specifies an invalid URL for ssh repos. Switching between ssh syntax and url syntax requires slightly more than just adding the 'ssh://' prefix - the delimiter between host and path changes from ':' to '/'.

This is a valid url:

```
ssh://user@server/project.git
```

This is an invalid url which git (and most other tools) will reject:

```
ssh://user@server:project.git
```
